### PR TITLE
Uglify .js files on change to javascripts_dir-min.

### DIFF
--- a/src/app_watcher.rb
+++ b/src/app_watcher.rb
@@ -10,6 +10,7 @@ module Compass
       def initialize(project_path, watches=[], options={}, poll=false)
         super
         @sass_watchers += coffeescript_watchers
+        @sass_watchers += javascript_watchers
         @sass_watchers += livereload_watchers
         setup_listener
       end
@@ -43,6 +44,24 @@ module Compass
         CoffeeCompiler.compile_folder( Compass.configuration.fireapp_coffeescripts_dir,
                                       Compass.configuration.javascripts_dir, 
                                       Compass.configuration.fireapp_coffeescript_options );
+      end
+
+      def javascript_watchers
+        javascript_filter = File.join(Compass.configuration.javascripts_dir,  "*.js")
+        child_javascript_filter = File.join(Compass.configuration.javascripts_dir, "**", "*.js")
+
+        JavascriptCompiler.minify_folder(Compass.configuration.javascripts_dir)
+
+        [ Watcher::Watch.new(child_javascript_filter, &method(:javascript_callback) ),
+          Watcher::Watch.new(javascript_filter, &method(:javascript_callback) ) ]
+      end
+
+      def javascript_callback(base, file, action)
+        log_action(:info, "Minifying: #{base} #{file}", options)
+        puts( "Minifying: #{base} #{file}", options)
+        file_to_minify = File.join(base, file)
+        javascripts_min_dir =  "#{Compass.configuration.javascripts_dir}-min"
+        JavascriptCompiler.minify_file(file_to_minify, Compass.configuration.javascripts_dir, javascripts_min_dir);
       end
 
       def livereload_watchers

--- a/src/compile_version.rb
+++ b/src/compile_version.rb
@@ -1,5 +1,5 @@
 	module CompileVersion
-	REVISION = '5af383b9ee'
-	COMPILE_TIME = '201306181508'
+	REVISION = '2c25c5db64'
+	COMPILE_TIME = '201306212127'
   UPDATE_URL = ''
 	end

--- a/src/javascript_compiler.rb
+++ b/src/javascript_compiler.rb
@@ -1,0 +1,78 @@
+
+require 'time'
+require 'pathname'
+require 'uglifier'
+require 'json'
+
+class JavascriptCompiler
+
+  def self.log(type, msg)new_js_path
+    msg = msg.sub(File.expand_path(Compass.configuration.project_path), '')[1..-1] if defined?(Tray) 
+
+    if defined?(Tray) && Tray.instance.logger
+      Tray.instance.logger.record type, msg
+    else  
+      puts "   #{type} #{msg}"
+    end
+  end
+
+  def self.minify_folder(javascripts_dir)
+    javascripts_dir = File.expand_path(javascripts_dir)
+    javascripts_min_dir = "#{javascripts_dir}-min"
+    #puts( "1 minifying #{javascripts_dir} #{javascripts_min_dir}")
+
+    Dir.glob( File.join(javascripts_dir, "**", "*.js")) do |full_path|
+      if full_path.index(".min.js") == nil #no double minification unless specifically set.
+        minify_file(full_path, javascripts_dir, javascripts_min_dir)
+      end
+    end
+  end
+
+  def self.minify_file(full_path, javascripts_dir, javascripts_min_dir)
+
+    javascripts_dir = File.expand_path(javascripts_dir)
+    javascripts_min_dir = File.expand_path(javascripts_min_dir)
+
+    full_path=File.expand_path(full_path)
+
+    new_js_path = get_new_js_path(full_path, javascripts_dir, javascripts_min_dir)
+    
+    # If the change is the file being deleted, delete the min.js one.
+    if File.exists?(full_path) == false
+      FileUtils.rm_rf(new_js_path)
+    else
+      minify(full_path, new_js_path)
+    end
+
+  end
+
+  def self.get_new_js_path(full_path, javascripts_dir, javascripts_min_dir)
+    full_path= File.expand_path(full_path)
+    new_dir  = File.dirname(full_path.to_s.sub(javascripts_dir, ''))
+
+    if full_path.index(".min.js") == nil #no adding min.min.js
+      new_file = File.basename(full_path).gsub(/\.js$/,".min.js")
+    else
+      new_file = File.basename(full_path)
+    end
+
+    return  File.join(javascripts_min_dir, new_dir, new_file)
+  end
+
+  def initialize(javascript_path)
+      @javascript_path   = Pathname.new(javascript_path)
+  end
+
+  def self.minify(full_path, new_js_path)
+
+    FileUtils.mkdir_p(File.dirname(new_js_path)) #make sure the folders exist
+
+    if File.exists?(new_js_path)
+      FileUtils.rm_rf(new_js_path)
+    end
+    File.open(new_js_path, 'w') do |f|
+      f.write(Uglifier.compile(File.read(full_path)))
+    end
+  end
+end
+

--- a/src/main.rb
+++ b/src/main.rb
@@ -64,6 +64,7 @@ begin
     require 'execjs'
     require "fsevent_patch" if App::OS == 'darwin'
     require "coffee_compiler.rb"
+    require "javascript_compiler.rb"
     require "app_watcher.rb"
     require "compass_patch.rb"
     require "sass_patch.rb"


### PR DESCRIPTION
This is a hackjob that works. This is my first project ever in ruby that involved doing anything other changing a line of code. I don't expect a straight pull into the main project, but it may be useful for others.

Features:
1. Watches all .js files in javascripts_dir folder recursively for changes and saves the uglified versions as filename.min.js to the folder "#{javascripts_dir}-min". 
2. Works with both LiveReload and coffeescript generated files.
3. Automatically uglifies all .js files on project load (except files named .min.js already)
4. Handles deleting .min.js files when .js files are deleted.
5. If you manually save a .min.js in your main js directory, it will create a minified version of it in your js-min folder, but will not change the extension to ".min.min.js".

Issues:
1. Needs to work with the configuration options to set minified folder names.
2. If your main /js/ folder contains "jquery.min.js" and "jquery.js" and you delete "jquery.min.js" it will also delete "/js-min/jquery.min.js"
3. Renaming a file will delete the old .min.js but not create a new file
