### PR TITLE
Fix chinese filename will crash.

### DIFF
--- a/src/app_watcher.rb
+++ b/src/app_watcher.rb
@@ -46,7 +46,7 @@ module Compass
                 glob,callback = watcher
                 callback.call(project_path, file, action) if File.fnmatch(glob, file)
               else
-                watcher.run_callback(project_path, relative_to(file, project_path), action) if watcher.match?(file)
+                watcher.run_callback(project_path, relative_to(file.force_encoding('utf-8').encode, project_path), action) if watcher.match?(file)
               end
             end
           end


### PR DESCRIPTION
If you accidentally put or create the file with chinese filename, Fireapp will throw exception.
It's like ruby 1.9 default encoding **US-ASCII**.
Exception Message:

```
incompatible character encodings: ASCII-8BIT and UTF-8
org/jruby/RubyString.java:3404:in `rindex'
jar:file:/Applications/Fire.app/Contents/Resources/Java/lib/java/jruby-complete.jar!/META-INF/jruby.home/lib/ruby/1.9/pathname.rb:48:in `chop_basename'
jar:file:/Applications/Fire.app/Contents/Resources/Java/lib/java/jruby-complete.jar!/META-INF/jruby.home/lib/ruby/1.9/pathname.rb:101:in `cleanpath_aggressive'
jar:file:/Applications/Fire.app/Contents/Resources/Java/lib/java/jruby-complete.jar!/META-INF/jruby.home/lib/ruby/1.9/pathname.rb:89:in `cleanpath'
jar:file:/Applications/Fire.app/Contents/Resources/Java/lib/java/jruby-complete.jar!/META-INF/jruby.home/lib/ruby/1.9/pathname.rb:450:in `relative_path_from'
/Applications/Fire.app/Contents/Resources/lib/ruby/compass_1.0/compass-1.0.0.alpha.17/lib/compass/watcher/project_watcher.rb:138:in `relative_to'
file:/Applications/Fire.app/Contents/Resources/Java/fire-app.jar!/app_watcher.rb:49:in `listen_callback'
org/jruby/RubyArray.java:1613:in `each'
file:/Applications/Fire.app/Contents/Resources/Java/fire-app.jar!/app_watcher.rb:44:in `listen_callback'
org/jruby/RubyHash.java:1338:in `each'
file:/Applications/Fire.app/Contents/Resources/Java/fire-app.jar!/app_watcher.rb:43:in `listen_callback'
org/jruby/RubyArray.java:1613:in `each'
file:/Applications/Fire.app/Contents/Resources/Java/fire-app.jar!/app_watcher.rb:42:in `listen_callback'
org/jruby/RubyProc.java:271:in `call'
/Applications/Fire.app/Contents/Resources/lib/ruby/jruby/listen-1.1.6/lib/listen/listener.rb:236:in `on_change'
/Applications/Fire.app/Contents/Resources/lib/ruby/jruby/listen-1.1.6/lib/listen/listener.rb:271:in `initialize_adapter'
org/jruby/RubyProc.java:271:in `call'
/Applications/Fire.app/Contents/Resources/lib/ruby/jruby/listen-1.1.6/lib/listen/adapter.rb:244:in `report_changes'
/Applications/Fire.app/Contents/Resources/lib/ruby/jruby/listen-1.1.6/lib/listen/adapter.rb:313:in `poll_changed_directories'
/Applications/Fire.app/Contents/Resources/lib/ruby/jruby/listen-1.1.6/lib/listen/adapter.rb:289:in `start_poller'
```
