### PR TITLE
將 javascripts_dir 改為 javascripts_path 支援自訂輸出目錄

### DIFF
--- a/src/app_watcher.rb
+++ b/src/app_watcher.rb
@@ -7,7 +7,7 @@ class  AppWatcher < Compass::Commands::WatchProject
     CompassHooker::WatchHooker.watches += livereload_watchers
     #@watchers += livescript_watchers
     #@watchers += coffeescript_watchers
-    
+
     CompassHooker::WatchHooker.watches  += custom_watcher(Compass.configuration.fireapp_coffeescripts_dir, "*.coffee", method(:coffee_callback))
     CompassHooker::WatchHooker.watches  += custom_watcher(Compass.configuration.fireapp_livescripts_dir, "*.ls", method(:livescript_callback))
     CompassHooker::WatchHooker.watches  += custom_watcher(Compass.configuration.fireapp_less_dir, "*.less", method(:less_callback))
@@ -18,7 +18,7 @@ class  AppWatcher < Compass::Commands::WatchProject
     perform
     sass_compiler.compile!
   end
-  
+
   def stop
     listener = sass_compiler.compiler.listener
 
@@ -41,7 +41,7 @@ class  AppWatcher < Compass::Commands::WatchProject
       filter = File.join(dir, extensions)
       child_filter = File.join(dir, "**", extensions)
     end
-    
+
 
     #[Compass::Configuration::Watch.new(filter, &callback),
     # Compass::Configuration::Watch.new(child_filter, &callback)]
@@ -52,7 +52,7 @@ class  AppWatcher < Compass::Commands::WatchProject
     log_action(:info, "#{file} was #{action}", options)
     puts( "#{file} was #{action}", options)
     CoffeeScriptCompiler.compile_folder( Compass.configuration.fireapp_coffeescripts_dir,
-                                  Compass.configuration.javascripts_dir, 
+                                  Compass.configuration.javascripts_path,
                                   Compass.configuration.fireapp_coffeescript_options );
   end
 
@@ -60,7 +60,7 @@ class  AppWatcher < Compass::Commands::WatchProject
     log_action(:info, "#{file} was #{action}", options)
     puts( "#{file} was #{action}", options)
     LiveScriptCompiler.compile_folder( Compass.configuration.fireapp_livescripts_dir,
-                                  Compass.configuration.javascripts_dir, 
+                                  Compass.configuration.javascripts_path,
                                   Compass.configuration.fireapp_livescript_options );
   end
 
@@ -70,7 +70,7 @@ class  AppWatcher < Compass::Commands::WatchProject
     log_action(:info, "#{file} was #{action}", options)
     puts( "#{file} was #{action}", options)
     LessCompiler.compile_folder( Compass.configuration.fireapp_less_dir,
-                                  Compass.configuration.css_dir, 
+                                  Compass.configuration.css_path,
                                   Compass.configuration.fireapp_less_options );
   end
 
@@ -92,7 +92,7 @@ class  AppWatcher < Compass::Commands::WatchProject
 
     tray = Tray.instance
     tray.shell.display.wake if tray.shell
-  end 
+  end
 
 
 end

--- a/src/hook/compass_patch.rb
+++ b/src/hook/compass_patch.rb
@@ -8,7 +8,7 @@ class Sass::Plugin::Compiler
   attr_accessor :listener
 
   m = instance_method("create_listener")
-  define_method("create_listener") do |*args, &block| 
+  define_method("create_listener") do |*args, &block|
     @listener = m.bind(self).(*args, &block)
   end
 
@@ -18,7 +18,7 @@ end
 # - use compiler.listener to get listener
 class Compass::SassCompiler
   attr_accessor :compiler # This compiler is Sass::Plugin::Compiler
-  
+
 end
 
 
@@ -28,17 +28,17 @@ class Compass::Commands::WatchProject
   attr_accessor :sass_compiler # This compiler is Compass::SassCompiler
 
   m = instance_method("new_compiler_instance")
-  define_method("new_compiler_instance") do |*args, &block| 
+  define_method("new_compiler_instance") do |*args, &block|
     @sass_compiler = m.bind(self).(*args, &block)
   end
 
   notify_watches = instance_method("notify_watches")
-  define_method("notify_watches") do |*args, &block| 
+  define_method("notify_watches") do |*args, &block|
     notify_watches.bind(self).(*args, &block)
     java.lang.System.gc()
   end
 
-  
+
 
 end
 
@@ -53,16 +53,16 @@ end
 class Compass::Commands::UpdateProject
 
   m = instance_method("perform")
-  define_method("perform") do |*args, &block| 
-    
+  define_method("perform") do |*args, &block|
+
     if File.exists?( Compass.configuration.fireapp_coffeescripts_dir )
-      CoffeeScriptCompiler.compile_folder( Compass.configuration.fireapp_coffeescripts_dir, Compass.configuration.javascripts_dir, Compass.configuration.fireapp_coffeescript_options );
+      CoffeeScriptCompiler.compile_folder( Compass.configuration.fireapp_coffeescripts_dir, Compass.configuration.javascripts_path, Compass.configuration.fireapp_coffeescript_options );
     end
     if File.exists?( Compass.configuration.fireapp_livescripts_dir )
-      LiveScriptCompiler.compile_folder( Compass.configuration.fireapp_livescripts_dir, Compass.configuration.javascripts_dir, Compass.configuration.fireapp_livescript_options );
+      LiveScriptCompiler.compile_folder( Compass.configuration.fireapp_livescripts_dir, Compass.configuration.javascripts_path, Compass.configuration.fireapp_livescript_options );
     end
     if File.exists?( Compass.configuration.fireapp_less_dir )
-      LessCompiler.compile_folder( Compass.configuration.fireapp_less_dir, Compass.configuration.css_dir, Compass.configuration.fireapp_less_options );
+      LessCompiler.compile_folder( Compass.configuration.fireapp_less_dir, Compass.configuration.css_path, Compass.configuration.fireapp_less_options );
     end
 
     m.bind(self).(*args, &block)
@@ -74,16 +74,16 @@ end
 class Compass::Commands::CleanProject
 
   m = instance_method("perform")
-  define_method("perform") do |*args, &block| 
-    
+  define_method("perform") do |*args, &block|
+
     if File.exists?( Compass.configuration.fireapp_coffeescripts_dir )
-      CoffeeScriptCompiler.clean_folder(Compass.configuration.fireapp_coffeescripts_dir, Compass.configuration.javascripts_dir )
+      CoffeeScriptCompiler.clean_folder(Compass.configuration.fireapp_coffeescripts_dir, Compass.configuration.javascripts_path )
     end
     if File.exists?( Compass.configuration.fireapp_livescripts_dir )
-      LiveScriptCompiler.clean_folder(Compass.configuration.fireapp_livescripts_dir, Compass.configuration.javascripts_dir )
+      LiveScriptCompiler.clean_folder(Compass.configuration.fireapp_livescripts_dir, Compass.configuration.javascripts_path )
     end
     if File.exists?( Compass.configuration.fireapp_less_dir )
-      LessCompiler.clean_folder(Compass.configuration.fireapp_less_dir, Compass.configuration.css_dir )
+      LessCompiler.clean_folder(Compass.configuration.fireapp_less_dir, Compass.configuration.css_path )
     end
 
     m.bind(self).(*args, &block)
@@ -95,7 +95,7 @@ end
 class Compass::Commands::StampPattern
 
   m = instance_method("perform")
-  define_method("perform") do |*args, &block| 
+  define_method("perform") do |*args, &block|
     m.bind(self).(*args, &block)
     FileUtils.rm_rf(Compass.configuration.cache_path)
   end
@@ -103,9 +103,9 @@ class Compass::Commands::StampPattern
 end
 
 # class Compass::Configuration::Watch
-  
+
 #   m = instance_method("match?")
-#   define_method("match?") do |*args, &block| 
+#   define_method("match?") do |*args, &block|
 
 #     changed_path = Pathname.new(args[0])
 #     project_path = Pathname.new(Compass.configuration.project_path)
@@ -122,8 +122,8 @@ end
 class Sass::Plugin::Compiler
 
   m = instance_method("update_stylesheet")
-  define_method("update_stylesheet") do |*args, &block| 
-    
+  define_method("update_stylesheet") do |*args, &block|
+
     sassfile_path = Pathname.new(args[0])
     project_path = Pathname.new(Compass.configuration.project_path)
 


### PR DESCRIPTION
#264 提到的問題。

在 MacOSX 10.9 測試過 CoffeeScript 正常運作。
