### PR TITLE
Fix notifier on non OSX

### DIFF
--- a/lib/ruby/common/terminal-notifier-1.4.2/lib/terminal-notifier.rb
+++ b/lib/ruby/common/terminal-notifier-1.4.2/lib/terminal-notifier.rb
@@ -3,7 +3,7 @@ module TerminalNotifier
 
   class UnsupportedPlatformError < StandardError; end
   def self.available?
-    @available ||= Gem::Version.new(version) > Gem::Version.new('10.8')
+    @available ||= (/darwin/ =~ RUBY_PLATFORM) && Gem::Version.new(version) > Gem::Version.new('10.8')
   end
 
   def self.version


### PR DESCRIPTION
Should fix the following issue:

Tested on my windows.

```
No such file or directory - uname
file:/D:/compass.app/lib/java/jruby-complete.jar!/jruby/kernel/jruby/process_manager.rb:24:in ``'
file:/D:/compass.app/lib/java/jruby-complete.jar!/jruby/kernel/jruby/process_manager.rb:49:in ``'
D:/compass.app/lib/ruby/common/terminal-notifier/lib/terminal-notifier.rb:12:in `version'
D:/compass.app/lib/ruby/common/terminal-notifier/lib/terminal-notifier.rb:8:in `available?'
file:/D:/compass.app/compass-app.jar!/notifier.rb:14:in `is_support'
file:/D:/compass.app/compass-app.jar!/app.rb:208:in `notify'
file:/D:/compass.app/compass-app.jar!/app.rb:41:in `show_and_clean_notifications'
org/jruby/RubyArray.java:1613:in `each'
file:/D:/compass.app/compass-app.jar!/app.rb:40:in `show_and_clean_notifications'
file:/D:/compass.app/compass-app.jar!/ui/tray.rb:71:in `run'
file:/D:/compass.app/compass-app.jar!/main.rb:129:in `run_tray'
file:/D:/compass.app/compass-app.jar!/main.rb:145:in `(root)'
org/jruby/RubyKernel.java:1071:in `require'
/D:/compass.app/lib/java/jruby-complete.jar!/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1:in `(root)'
/D:/compass.app/lib/java/jruby-complete.jar!/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:54:in `require'
```